### PR TITLE
Test Retained Messages on Clean Session

### DIFF
--- a/tests/test_broker.py
+++ b/tests/test_broker.py
@@ -774,33 +774,38 @@ class BrokerTest(unittest.TestCase):
         if future.exception():
             raise future.exception()
 
-
-    @patch('hbmqtt.broker.PluginManager', new_callable=AsyncMock)
+    @patch("hbmqtt.broker.PluginManager", new_callable=AsyncMock)
     def test_client_publish_retain_subscribe(self, MockPluginManager):
         async def test_coro():
             try:
-                broker = Broker(self._test_config, plugin_namespace="hbmqtt.test.plugins")
+                broker = Broker(
+                    self._test_config, plugin_namespace="hbmqtt.test.plugins"
+                )
                 await broker.start()
                 self.assertTrue(broker.transitions.is_started())
                 sub_client = MQTTClient()
-                await sub_client.connect(f'mqtt://127.0.0.1:{self._test_port}', cleansession=True)
-                ret = await sub_client.subscribe([('/qos0', QOS_0), ('/qos1', QOS_1), ('/qos2', QOS_2)])
+                await sub_client.connect(
+                    f"mqtt://127.0.0.1:{self._test_port}", cleansession=True
+                )
+                ret = await sub_client.subscribe(
+                    [("/qos0", QOS_0), ("/qos1", QOS_1), ("/qos2", QOS_2)]
+                )
                 self.assertEquals(ret, [QOS_0, QOS_1, QOS_2])
                 await sub_client.disconnect()
                 await asyncio.sleep(0.1)
 
-                await self._client_publish('/qos0', b'data', QOS_0, retain=True)
-                await self._client_publish('/qos1', b'data', QOS_1, retain=True)
-                await self._client_publish('/qos2', b'data', QOS_2, retain=True)
+                await self._client_publish("/qos0", b"data", QOS_0, retain=True)
+                await self._client_publish("/qos1", b"data", QOS_1, retain=True)
+                await self._client_publish("/qos2", b"data", QOS_2, retain=True)
                 await sub_client.reconnect()
                 for qos in [QOS_0, QOS_1, QOS_2]:
                     log.debug("TEST QOS: %d" % qos)
-                    await sub_client.subscribe([(f'/qos{qos}', qos)])
+                    await sub_client.subscribe([(f"/qos{qos}", qos)])
                     message = await sub_client.deliver_message()
                     log.debug("Message: " + repr(message.publish_packet))
                     self.assertIsNotNone(message)
-                    self.assertEquals(message.topic, '/qos%s' % qos)
-                    self.assertEquals(message.data, b'data')
+                    self.assertEquals(message.topic, "/qos%s" % qos)
+                    self.assertEquals(message.data, b"data")
                     self.assertEquals(message.qos, qos)
                 await sub_client.disconnect()
                 await asyncio.sleep(0.1)
@@ -814,7 +819,6 @@ class BrokerTest(unittest.TestCase):
         self.loop.run_until_complete(test_coro())
         if future.exception():
             raise future.exception()
-
 
     async def _client_publish(self, topic, data, qos, retain=False):
         pub_client = MQTTClient()

--- a/tests/test_broker.py
+++ b/tests/test_broker.py
@@ -774,7 +774,7 @@ class BrokerTest(unittest.TestCase):
         if future.exception():
             raise future.exception()
 
-    """
+
     @patch('hbmqtt.broker.PluginManager', new_callable=AsyncMock)
     def test_client_publish_retain_subscribe(self, MockPluginManager):
         async def test_coro():
@@ -783,7 +783,7 @@ class BrokerTest(unittest.TestCase):
                 await broker.start()
                 self.assertTrue(broker.transitions.is_started())
                 sub_client = MQTTClient()
-                await sub_client.connect(f'mqtt://127.0.0.1:{self._test_port}', cleansession=False)
+                await sub_client.connect(f'mqtt://127.0.0.1:{self._test_port}', cleansession=True)
                 ret = await sub_client.subscribe([('/qos0', QOS_0), ('/qos1', QOS_1), ('/qos2', QOS_2)])
                 self.assertEquals(ret, [QOS_0, QOS_1, QOS_2])
                 await sub_client.disconnect()
@@ -795,12 +795,13 @@ class BrokerTest(unittest.TestCase):
                 await sub_client.reconnect()
                 for qos in [QOS_0, QOS_1, QOS_2]:
                     log.debug("TEST QOS: %d" % qos)
+                    await sub_client.subscribe([(f'/qos{qos}', qos)])
                     message = await sub_client.deliver_message()
                     log.debug("Message: " + repr(message.publish_packet))
                     self.assertIsNotNone(message)
-                    # self.assertEquals(message.topic, '/qos%s' % qos)
+                    self.assertEquals(message.topic, '/qos%s' % qos)
                     self.assertEquals(message.data, b'data')
-                    # self.assertEquals(message.qos, qos)
+                    self.assertEquals(message.qos, qos)
                 await sub_client.disconnect()
                 await asyncio.sleep(0.1)
                 await broker.shutdown()
@@ -813,7 +814,7 @@ class BrokerTest(unittest.TestCase):
         self.loop.run_until_complete(test_coro())
         if future.exception():
             raise future.exception()
-    """
+
 
     async def _client_publish(self, topic, data, qos, retain=False):
         pub_client = MQTTClient()


### PR DESCRIPTION
This test was failing when I forked it. If I am understanding the point of the test, it is meant to ensure that retained messages are sent on topic subscription. They were relying on cached sessions on reconnect to maintain subscriptions, but that doesn't trigger the sending of retained messages in their broker implementation. I switched the test to use a clean session and manually re-subscribe to the topics.

Though this makes it pass, I am unsure if this is actually the correct behavior according to the MQTT spec. I'm pretty sure the only way to figure that out for sure is to go spelunking in the spec... which seems like a lot of unrelated work to making all of these tests pass.