### PR TITLE
Handle MQTT Client Takeover

### DIFF
--- a/hbmqtt/broker.py
+++ b/hbmqtt/broker.py
@@ -406,6 +406,7 @@ class Broker:
     ):
         # Wait for connection available on listener
         server = self._servers.get(listener_name, None)
+        print(self._sessions)
         if not server:
             raise BrokerException("Invalid listener name '%s'" % listener_name)
         await server.acquire_connection()
@@ -460,9 +461,6 @@ class Broker:
             client_session.keep_alive += self.config["timeout-disconnect-delay"]
         self.logger.debug("Keep-alive timeout=%d" % client_session.keep_alive)
 
-        handler.attach(client_session, reader, writer)
-        self._sessions[client_session.client_id] = (client_session, handler)
-
         authenticated = await self.authenticate(
             client_session, self.listeners_config[listener_name]
         )
@@ -477,12 +475,25 @@ class Broker:
                 break
             except (MachineError, ValueError):
                 # Backwards compat: MachineError is raised by transitions < 0.5.0.
-                self.logger.warning(
-                    "Client %s is reconnecting too quickly, make it wait"
-                    % client_session.client_id
-                )
-                # Wait a bit may be client is reconnecting too fast
-                await asyncio.sleep(1, loop=self._loop)
+                if client_session.transitions.is_connected():
+                    self.logger.warning(
+                        "Client %s is already connected, performing take-over.",
+                        client_session.client_id,
+                    )
+                    old_session = self._sessions[client_session.client_id]
+                    await old_session[1].stop()
+                    break
+                else:
+                    self.logger.warning(
+                        "Client %s is reconnecting too quickly, make it wait"
+                        % client_session.client_id
+                    )
+                    # Wait a bit may be client is reconnecting too fast
+                    await asyncio.sleep(1, loop=self._loop)
+
+        handler.attach(client_session, reader, writer)
+        self._sessions[client_session.client_id] = (client_session, handler)
+
         await handler.mqtt_connack_authorize(authenticated)
 
         await self.plugins_manager.fire_event(

--- a/hbmqtt/broker.py
+++ b/hbmqtt/broker.py
@@ -479,9 +479,9 @@ class Broker:
                         "Client %s is already connected, performing take-over.",
                         client_session.client_id,
                     )
-                    old_session = self._sessions[client_session.client_id]
-                    await old_session[1].handle_connection_closed()
-                    await old_session[1].stop()
+                    old_handler = self._sessions[client_session.client_id][1]
+                    await old_handler.handle_connection_closed()
+                    await old_handler.stop()
                     break
                 else:
                     self.logger.warning(

--- a/hbmqtt/broker.py
+++ b/hbmqtt/broker.py
@@ -406,7 +406,6 @@ class Broker:
     ):
         # Wait for connection available on listener
         server = self._servers.get(listener_name, None)
-        print(self._sessions)
         if not server:
             raise BrokerException("Invalid listener name '%s'" % listener_name)
         await server.acquire_connection()
@@ -481,6 +480,7 @@ class Broker:
                         client_session.client_id,
                     )
                     old_session = self._sessions[client_session.client_id]
+                    await old_session[1].handle_connection_closed()
                     await old_session[1].stop()
                     break
                 else:


### PR DESCRIPTION
If a client connected with the same client ID as a currently assumed to be connected client, we will close the previous connection and hand the session over to the new client.