### PR TITLE
You can't await an asyncio.Lock

### DIFF
--- a/hbmqtt/mqtt/protocol/handler.py
+++ b/hbmqtt/mqtt/protocol/handler.py
@@ -536,7 +536,7 @@ class ProtocolHandler:
 
     async def _send_packet(self, packet):
         try:
-            with (await self._write_lock):
+            async with self._write_lock:
                 await packet.to_stream(self.writer)
             if self._keepalive_task:
                 self._keepalive_task.cancel()


### PR DESCRIPTION
I'm not sure if this was valid syntax before, but it doesn't work with Python 3.8. The preferred
syntax seems to be "async with lock:" to acquire a lock, run a section of code, and then release
a lock.